### PR TITLE
Add ECDHE-RSA-AES256-SHA to nginx.conf

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -63,7 +63,7 @@ server {
     ssl_session_timeout 10m;
 
     # Only strong ciphers in PFS mode
-    ssl_ciphers DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
+    ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
     ssl_protocols SSLv3 TLSv1;
 
     # For ssl client certificates, edit ssl_client_certificate


### PR DESCRIPTION
 \* Add the ECDHE-RSA-AES256-SHA (Elliptic Diffie Hellman Key Exchange, RSA Auth, AES256 confidentiality, SHA1 integrity) cipher suite to nginx configuration.
 \* This cipher suite has been available in nginx since the release of version 1.1.0 (http://forum.nginx.org/read.php?2,213199,213215)
