### PR TITLE
Enable TLSv1.1 and TLSv1.2 for Apache

### DIFF
--- a/configs/apache2/https-hsts.conf
+++ b/configs/apache2/https-hsts.conf
@@ -39,7 +39,7 @@ NameVirtualHost 1.2.3.4:443
     SSLCertificateFile /etc/apache2/ssl/www.example.com.crt
     SSLCertificateKeyFile /etc/apache2/ssl/www.example.com.key
 
-    SSLProtocol -all +SSLv3 +TLSv1
+    SSLProtocol all -SSLv2
     SSLCipherSuite HIGH:!aNULL:!SSLv2:!MD5:@STRENGTH
     SSLHonorCipherOrder on
     SSLCompression off


### PR DESCRIPTION
If linked against OpenSSL 1.0.1, mod_ssl can use v1.1 and v1.2 of TLS;
manually specifying the versions to enable will prevent these from
being used when available.

http://httpd.apache.org/docs/2.2/mod/mod_ssl.html#sslprotocol
