### PR TITLE
Use ciphers as recommended by Qualys

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -63,7 +63,7 @@ server {
     ssl_session_timeout 10m;
 
     # Only strong ciphers in PFS mode
-    ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
+    ssl_ciphers ECDHE-RSA-AES128-SHA256:AES128-GCM-SHA256:RC4:HIGH:!MD5:!aNULL:!EDH;
     ssl_protocols SSLv3 TLSv1;
 
     # For ssl client certificates, edit ssl_client_certificate


### PR DESCRIPTION
This puts some TLS 1.2 cipher suites first so clients
which support them will pick those first. TLS 1.0 clients
will use RC4.

https://community.qualys.com/blogs/securitylabs/2011/10/17/mitigating-the-beast-attack-on-tls
