### PR TITLE
Update sshd MACs list

### DIFF
--- a/configs/sshd/sshd-pfs_config
+++ b/configs/sshd/sshd-pfs_config
@@ -1,2 +1,2 @@
 Ciphers aes256-ctr
-MACs hmac-sha1
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1


### PR DESCRIPTION
Update `sshd`'s preferred MACs list in order to

a) favor stronger hash functions (`sha512` and `sha256`) over `sha1`
b) favor Encrypt-then-MAC (`*-etm`) modes over regular (Encrypt-and-MAC) modes.

The Encrypt-then-MAC modes were released as part of [OpenSSH 6.2](http://www.openssh.com/txt/release-6.2).
