### PR TITLE
Comment out Tor-specific config

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -74,12 +74,14 @@ server {
 
     server_name  example.com;
     location / {
-        proxy_pass  http://127.0.0.1:8118;
-        proxy_read_timeout 2000;
+        # Uncomment to route requests through Tor.
+        # proxy_pass  http://127.0.0.1:8118;
+        # proxy_set_header Host $server_id.onion;
+        # proxy_read_timeout 2000;
+        
         if ($host ~* (.*).example.com) {
             set $server_id $1;
         }
-        proxy_set_header Host $server_id.onion;
         # 31536000 == 1 year
         add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
         add_header X-Frame-Options DENY;


### PR DESCRIPTION
There're some config lines in here that seem only relevant if you're proxying through Tor, which most sites that aren't tor2web aren't doing. I commented them out.

It'd be potentially nice to detect whether a user is coming from Tor, and redirect them to one's own hidden server. Not sure how to do that well.
