### PR TITLE
Remove explicit listing of TLSv1 / SSLv3

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -63,8 +63,7 @@ server {
     ssl_session_timeout 10m;
 
     # Only strong ciphers in PFS mode
-    ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
-    ssl_protocols SSLv3 TLSv1;
+    ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA:-SSLv2;
 
     # For ssl client certificates, edit ssl_client_certificate
     # (specifies a file containing permissable CAs) and uncomment the


### PR DESCRIPTION
The explicit protocol list meant this config previously excluded TLS 1.1 and 1.2.

"Since versions 1.1.13 and 1.0.12, nginx uses “ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2” by default." - http://nginx.org/en/docs/http/configuring_https_servers.html

Add -SSLv2 to the cipher list for safety in case this config is used with an old (<0.8.18) version of nginx.
