### PR TITLE
httpd: Use highest TLS versions server supports

### DIFF
--- a/configs/apache2/https-hsts.conf
+++ b/configs/apache2/https-hsts.conf
@@ -39,7 +39,7 @@ NameVirtualHost 1.2.3.4:443
     SSLCertificateFile /etc/apache2/ssl/www.example.com.crt
     SSLCertificateKeyFile /etc/apache2/ssl/www.example.com.key
 
-    SSLProtocol -ALL +SSLv3 +TLSv1 +TLSv1.1 +TLSv1.2
+    SSLProtocol all -SSLv2
     SSLCipherSuite ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:!RC4:HIGH:!MD5:!aNULL:!EDH
     SSLHonorCipherOrder on
     SSLCompression off


### PR DESCRIPTION
This is exactly the same change I made back in #9.  However, it needs to be made once again because #16 went back to whitelisting versions, without any explanation of why this is better.  I can, however, come up with several reasons why a blacklist is preferable:
1. The config will be suitable for versions of Apache/OpenSSL that don't support TLS 1.1 and 1.2.
2. Newer versions of TLS will be automatically enabled when supported.  There is, practically speaking, _no_ chance those will decrease, rather than increase, security.
