### PR TITLE
enable support for TLSv1.1 and TLSv1.2

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -64,7 +64,7 @@ server {
 
     # Only strong ciphers in PFS mode
     ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
-    ssl_protocols SSLv3 TLSv1;
+    ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
 
     # For ssl client certificates, edit ssl_client_certificate
     # (specifies a file containing permissable CAs) and uncomment the


### PR DESCRIPTION
This patch enables support for TLSv1.1 and TLSv1.2 on nginx.
