### PR TITLE
add openssl option to use SHA2

### DIFF
--- a/startssl/README.markdown
+++ b/startssl/README.markdown
@@ -8,7 +8,7 @@ The CA which we'll use is StartSSL. They provide basic certificates for free, al
 
 A keypair can be generated with OpenSSL:
 
-    openssl req -new -newkey rsa:2048 -keyout example.com.key -nodes -out example.com.csr
+    openssl req -new -sha256 -newkey rsa:2048 -keyout example.com.key -nodes -out example.com.csr
 
 This command will prompt you for a country name, state name etc. *All of this can be ignored*. Just hit enter to accept the defaults because StartSSL doesn't use that information.
 


### PR DESCRIPTION
SHA1 is [dangerously weak](http://arstechnica.com/security/2012/10/sha1-crypto-algorithm-could-fall-by-2018/) and in fact Google Chrome will soon start warning about it. Using this option should make things more future-proof.
