### PR TITLE
Correct syntax for Strict-Transport-Security and subdomains

### DIFF
--- a/configs/apache2/https-hsts.conf
+++ b/configs/apache2/https-hsts.conf
@@ -47,7 +47,7 @@ NameVirtualHost 1.2.3.4:443
     # Add six earth month HSTS header for all users...
     Header add Strict-Transport-Security "max-age=15768000"
     # If you want to protect all subdomains, use the following header
-    # Strict-Transport-Security: max-age=15768000 ; includeSubDomains
+    # Header always set Strict-Transport-Security "max-age=15768000; includeSubDomains"
 
     DocumentRoot /var/www/https-root/
 


### PR DESCRIPTION
At least on a Debian Wheezy, the previous line does not pass `apache2ctl configtest`.
