### PR TITLE
https-hsts.conf: SSLProtocol: whitelist TLSv* -> blacklist SSLv*

### DIFF
--- a/configs/apache2/https-hsts.conf
+++ b/configs/apache2/https-hsts.conf
@@ -39,7 +39,7 @@ NameVirtualHost 1.2.3.4:443
     SSLCertificateFile /etc/apache2/ssl/www.example.com.crt
     SSLCertificateKeyFile /etc/apache2/ssl/www.example.com.key
 
-    SSLProtocol -ALL +TLSv1 +TLSv1.1 +TLSv1.2
+    SSLProtocol All -SSLv2 -SSLv3
     SSLCipherSuite ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:!RC4:HIGH:!MD5:!aNULL:!EDH
     SSLHonorCipherOrder on
     SSLCompression off


### PR DESCRIPTION
as libraries expand, they'll get TLSv1.3 automatically. https://github.com/ioerror/duraconf/pull/43
