### PR TITLE
Improved secret key encryption

### DIFF
--- a/configs/gnupg/gpg.conf
+++ b/configs/gnupg/gpg.conf
@@ -88,3 +88,7 @@ cert-digest-algo SHA512
 # This preference list is used for new keys and becomes the default for
 # "setpref" in the edit menu
 default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 ZLIB BZIP2 ZIP Uncompressed
+
+# Private key material encryption algorythms
+s2k-cipher-algo AES256
+s2k-digest-algo SHA512


### PR DESCRIPTION
GnuPG defaults for secret key encryption are not so good, see:
https://www.gnupg.org/documentation/manuals/gnupg/OpenPGP-Options.html

