### PR TITLE
Added hardended SSH client preferences

### DIFF
--- a/configs/nginx/nginx.conf
+++ b/configs/nginx/nginx.conf
@@ -2,7 +2,7 @@
 # This is an example of a high security, somewhat compatible TLSv1
 # enabled HTTPS proxy server. The server only allows modes that provide perfect
 # forward secrecy; no other modes are offered. Anonymous cipher modes are
-# disabled.  This configuation does not include the HSTS header to ensure that
+# disabled.  This configuation includes the HSTS header to ensure that
 # users do not accidentally connect to an insecure HTTP service after their
 # first visit. This configuration will automatically redirect all traffic on
 # TCP port 80 to TCP port 443. All traffic requested will be redirected through
@@ -46,45 +46,45 @@ http {
     proxy_cache_path                /var/cache/nginx/cached levels=2:2
     keys_zone=global:64m inactive=60m max_size=1G;
 
-server {
-    listen 1.2.3.4:80;
-    return 301 https://$host$request_uri;
-}
-server {
-    listen 1.2.3.4:443 default ssl;
-    ssl_certificate      /etc/nginx/example.com.crt;
-    ssl_certificate_key  /etc/nginx/example.com.key;
-    ssl_prefer_server_ciphers on;
-    ssl_session_cache shared:SSL:10m;
-    ssl_session_timeout 10m;
-
-    # Only strong ciphers in PFS mode
-    ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-
-    # For ssl client certificates, edit ssl_client_certificate
-    # (specifies a file containing permissable CAs) and uncomment the
-    # following:
-    #ssl_verify_client optional;
-    #ssl_client_certificate /etc/ssl/ca.crt
-
-    server_name  example.com;
-    location / {
-        # Uncomment to route requests through Tor.
-        # proxy_pass  http://127.0.0.1:8118;
-        # proxy_set_header Host $server_id.onion;
-        # proxy_read_timeout 2000;
-        
-        if ($host ~* (.*).example.com) {
-            set $server_id $1;
-        }
-        # 31536000 == 1 year
-        add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
-        add_header X-Frame-Options DENY;
-    proxy_cache global;
-    proxy_cache_valid  any 1h;
-    proxy_cache_use_stale updating;
-
+    server {
+        listen 1.2.3.4:80;
+        return 301 https://$host$request_uri;
     }
-}
+
+    server {
+        listen 1.2.3.4:443 default ssl;
+        ssl_certificate      /etc/nginx/example.com.crt;
+        ssl_certificate_key  /etc/nginx/example.com.key;
+        ssl_prefer_server_ciphers on;
+        ssl_session_cache shared:SSL:10m;
+        ssl_session_timeout 10m;
+
+        # Only strong ciphers in PFS mode
+        ssl_ciphers ECDHE-RSA-AES256-SHA:DHE-RSA-AES256-SHA:DHE-DSS-AES256-SHA:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA;
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+
+        # For ssl client certificates, edit ssl_client_certificate
+        # (specifies a file containing permissable CAs) and uncomment the
+        # following:
+        #ssl_verify_client optional;
+        #ssl_client_certificate /etc/ssl/ca.crt
+
+        server_name  example.com;
+        location / {
+            # Uncomment to route requests through Tor.
+            # proxy_pass  http://127.0.0.1:8118;
+            # proxy_set_header Host $server_id.onion;
+            # proxy_read_timeout 2000;
+
+            if ($host ~* (.*).example.com) {
+                set $server_id $1;
+            }
+            # 31536000 == 1 year
+            add_header Strict-Transport-Security "max-age=31536000; includeSubdomains";
+            add_header X-Frame-Options DENY;
+            proxy_cache global;
+            proxy_cache_valid  any 1h;
+            proxy_cache_use_stale updating;
+        }
+    }
 }

--- a/configs/ssh/ssh_config
+++ b/configs/ssh/ssh_config
@@ -1,0 +1,12 @@
+# ssh_config — OpenSSH SSH client configuration files
+
+# Version 2 cipher preference list
+# (Only reordered from default, no ciphers dropped)
+# Defaule value from manual: aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,arcfour256,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes192-cbc,aes256-cbc,arcfour
+# Note: AES-GCM may be more efficient than AES-CTR+HMAC, without losing security
+Ciphers aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com,arcfour256,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes256-cbc,aes192-cbc,arcfour
+
+# Version 2 MAC preference list
+# (Only reordered from default, no MACs dropped)
+# Default value from manual: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-md5-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-md5,hmac-sha1,hmac-ripemd160,hmac-sha1-96,hmac-md5-96
+MACs umac-128-etm@openssh.com,umac-64-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128@openssh.com,umac-64@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-md5,hmac-sha1,hmac-ripemd160,hmac-sha1-96,hmac-md5-96

--- a/configs/sshd/sshd-pfs_config
+++ b/configs/sshd/sshd-pfs_config
@@ -1,11 +1,34 @@
-# Specifies the ciphers allowed for protocol version 2.
-# The default is: aes128-ctr,aes192-ctr,aes256-ctr,arcfour256,
-# arcfour128,aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes192-cbc,
-# aes256-cbc,arcfour
-Ciphers aes256-ctr
+# Protocol v1 is broken.
+Protocol 2
+
+# Specifies the available key exchange algorithms.
+# 1. ECDH over Curve25519 with SHA256
+# 2. Custom DH with SHA256 - generate primes using
+#    ssh-keygen -G /tmp/moduli -b 4096
+#    ssh-keygen -T /etc/ssh/moduli -f /tmp/moduli
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+
+# Server authentication
+# 1. Ed25519 - generate key using 
+#    ssh-keygen -t ed25519 -f ssh_host_ed25519_key < /dev/null
+# 2. RSA - generate key using
+#    ssh-keygen -t rsa -b 4096 -f ssh_host_rsa_key < /dev/null
+HostKey /etc/ssh/ssh_host_ed25519_key
+HostKey /etc/ssh/ssh_host_rsa_key
+
+# Client authentication
+ChallengeResponseAuthentication no
+PasswordAuthentication no
+PubkeyAuthentication yes
+
+# Specifies the allowed ciphers
+# 1. Chacha20-Poly1305 - Authenticated encryption, message length encrypted
+# 2. AES-GCM - Authenticated encryption, message length is Additional Data
+# 3. AES-CTR - Confidentiality only, works better with flawed Encrypt-and-MAC
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
 
 # Specifies the available MAC (message authentication code) algorithms.
-# The default is: hmac-md5,hmac-sha1,umac-64@openssh.com,hmac-ripemd160,
-# hmac-sha1-96,hmac-md5-96,hmac-sha2-256,hmac-sha256-96,hmac-sha2-512,
-# hmac-sha2-512-96
-MACs hmac-sha2-512
+# 1. Encrypt-then-MAC with at least 128 bit tags and keys - provable security
+# 2. Encrypt-and-MAC with at least 128 bit tags and keys - no security proof
+#    probably fine with a CTR cipher, don't use them with CBC
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128


### PR DESCRIPTION
There is already a hardened SSH server configuration file, but this new SSH client configuration file will make OpenSSH SSH client prefer stronger ciphers and MACs when the server in question doesn't enforce stronger ciphers and MACs.