### PR TITLE
Added hardended SSH client preferences

### DIFF
--- a/configs/ssh/ssh_config
+++ b/configs/ssh/ssh_config
@@ -1,0 +1,12 @@
+# ssh_config — OpenSSH SSH client configuration files
+
+# Version 2 cipher preference list
+# (Only reordered from default, no ciphers dropped)
+# Defaule value from manual: aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,arcfour256,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes192-cbc,aes256-cbc,arcfour
+# Note: AES-GCM may be more efficient than AES-CTR+HMAC, without losing security
+Ciphers aes256-ctr,aes192-ctr,aes128-ctr,aes256-gcm@openssh.com,aes128-gcm@openssh.com,chacha20-poly1305@openssh.com,arcfour256,arcfour128,aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes256-cbc,aes192-cbc,arcfour
+
+# Version 2 MAC preference list
+# (Only reordered from default, no MACs dropped)
+# Default value from manual: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-md5-etm@openssh.com,hmac-sha1-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-md5,hmac-sha1,hmac-ripemd160,hmac-sha1-96,hmac-md5-96
+MACs umac-128-etm@openssh.com,umac-64-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128@openssh.com,umac-64@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-sha1-etm@openssh.com,hmac-md5-etm@openssh.com,hmac-ripemd160-etm@openssh.com,hmac-sha1-96-etm@openssh.com,hmac-md5-96-etm@openssh.com,hmac-md5,hmac-sha1,hmac-ripemd160,hmac-sha1-96,hmac-md5-96


### PR DESCRIPTION
There is already a hardened SSH server configuration file, but this new SSH client configuration file will make OpenSSH SSH client prefer stronger ciphers and MACs when the server in question doesn't enforce stronger ciphers and MACs.