### PR TITLE
update gpg.conf

### DIFF
--- a/configs/gnupg/gpg.conf
+++ b/configs/gnupg/gpg.conf
@@ -11,7 +11,7 @@
 # The default key to sign with. If this option is not used, the default key is
 # the first key found in the secret keyring
 
-#default-key 0xD8692123C4065DEA5E0F3AB5249B39D24F25E3B6
+default-key 
 
 
 #-----------------------------
@@ -39,17 +39,22 @@ verify-options show-uid-validity
 use-agent
 
 
+# Create anonymous messages
+#throw-keyid
+
 #-----------------------------
 # keyserver
 #-----------------------------
 
 # This is the server that --recv-keys, --send-keys, and --search-keys will
 # communicate with to receive keys from, send keys to, and search for keys on
+# !! Remember to install gnupg-curl or you will get the following error:
+# gpgkeys: HTTP fetch error 1: unsupported protocol
 keyserver hkps://hkps.pool.sks-keyservers.net
 
 # Provide a certificate store to override the system default
 # Get this from https://sks-keyservers.net/sks-keyservers.netCA.pem
-keyserver-options ca-cert-file=/usr/local/etc/ssl/certs/hkps.pool.sks-keyservers.net.pem
+keyserver-options ca-cert-file=/etc/ssl/certs/sks-keyservers.netCA.pem
 
 # Set the proxy to use for HTTP and HKP keyservers - default to the standard
 # local Tor socks proxy
@@ -76,15 +81,28 @@ keyserver-options include-revoked
 
 # list of personal digest preferences. When multiple digests are supported by
 # all recipients, choose the strongest one
-personal-cipher-preferences AES256 AES192 AES CAST5
+personal-cipher-preferences AES256 BLOWFISH
 
 # list of personal digest preferences. When multiple ciphers are supported by
 # all recipients, choose the strongest one
-personal-digest-preferences SHA512 SHA384 SHA256 SHA224
+personal-digest-preferences SHA512 SHA256
 
 # message digest algorithm used when signing a key
 cert-digest-algo SHA512
 
 # This preference list is used for new keys and becomes the default for
 # "setpref" in the edit menu
-default-preference-list SHA512 SHA384 SHA256 SHA224 AES256 AES192 AES CAST5 ZLIB BZIP2 ZIP Uncompressed
+default-preference-list SHA512 SHA256 AES256 BLOWFISH ZLIB BZIP2 ZIP Uncompressed
+
+# To protect secret keys
+s2k-cipher-algo BLOWFISH 
+s2k-digest-algo SHA512 
+s2k-mode 3
+
+# Use the following when encrypting/signing in (a)symmetric mode
+cipher-algo AES256
+digest-algo SHA512
+compress-algo 2
+
+# Disable insecure algos
+disable-cipher-algo 3DES IDEA

--- a/configs/gnupg/gpg.conf
+++ b/configs/gnupg/gpg.conf
@@ -1,6 +1,7 @@
 #
 # This is an implementation of the Riseup OpenPGP Best Practices
 # https://help.riseup.net/en/security/message-security/openpgp/best-practices
+# Modified by HacKan
 #
 
 
@@ -11,7 +12,7 @@
 # The default key to sign with. If this option is not used, the default key is
 # the first key found in the secret keyring
 
-default-key 
+#default-key
 
 
 #-----------------------------
@@ -48,8 +49,6 @@ use-agent
 
 # This is the server that --recv-keys, --send-keys, and --search-keys will
 # communicate with to receive keys from, send keys to, and search for keys on
-# !! Remember to install gnupg-curl or you will get the following error:
-# gpgkeys: HTTP fetch error 1: unsupported protocol
 keyserver hkps://hkps.pool.sks-keyservers.net
 
 # Provide a certificate store to override the system default
@@ -81,21 +80,21 @@ keyserver-options include-revoked
 
 # list of personal digest preferences. When multiple digests are supported by
 # all recipients, choose the strongest one
-personal-cipher-preferences AES256 BLOWFISH
+personal-cipher-preferences AES256 TWOFISH
 
 # list of personal digest preferences. When multiple ciphers are supported by
 # all recipients, choose the strongest one
-personal-digest-preferences SHA512 SHA256
+personal-digest-preferences SHA512 SHA384
 
 # message digest algorithm used when signing a key
 cert-digest-algo SHA512
 
 # This preference list is used for new keys and becomes the default for
 # "setpref" in the edit menu
-default-preference-list SHA512 SHA256 AES256 BLOWFISH ZLIB BZIP2 ZIP Uncompressed
+default-preference-list SHA512 SHA384 SHA256 SHA224 RIPEMD160 AES256 TWOFISH BLOWFISH CAMELLIA256 CAST5 ZLIB BZIP2 ZIP Uncompressed
 
 # To protect secret keys
-s2k-cipher-algo BLOWFISH 
+s2k-cipher-algo TWOFISH 
 s2k-digest-algo SHA512 
 s2k-mode 3
 
@@ -106,3 +105,6 @@ compress-algo 2
 
 # Disable insecure algos
 disable-cipher-algo 3DES IDEA
+
+# Force the use of encryption with a modification detection code.
+force-mdc


### PR DESCRIPTION
Use more secure options, added options for the secret key and to use when encrypting/signing messages/files because by default sha-1 or ripemd160 and blowfish will be use
