### PR TITLE
Fix copy & paste errors

### DIFF
--- a/configs/gnupg/gpg.conf
+++ b/configs/gnupg/gpg.conf
@@ -74,11 +74,11 @@ keyserver-options include-revoked
 # algorithm and ciphers
 #-----------------------------
 
-# list of personal digest preferences. When multiple digests are supported by
+# list of personal cipher preferences. When multiple ciphers are supported by
 # all recipients, choose the strongest one
 personal-cipher-preferences AES256 AES192 AES CAST5
 
-# list of personal digest preferences. When multiple ciphers are supported by
+# list of personal digest preferences. When multiple digests are supported by
 # all recipients, choose the strongest one
 personal-digest-preferences SHA512 SHA384 SHA256 SHA224
 


### PR DESCRIPTION
The comments do not properly distinguish between cipher and digest.
Fix comments so they describe the correct things.