### PR TITLE
Use keys.openpgp.org keyserver for reasons

### DIFF
--- a/configs/gnupg/gpg.conf
+++ b/configs/gnupg/gpg.conf
@@ -45,11 +45,7 @@ use-agent
 
 # This is the server that --recv-keys, --send-keys, and --search-keys will
 # communicate with to receive keys from, send keys to, and search for keys on
-keyserver hkps://hkps.pool.sks-keyservers.net
-
-# Provide a certificate store to override the system default
-# Get this from https://sks-keyservers.net/sks-keyservers.netCA.pem
-keyserver-options ca-cert-file=/usr/local/etc/ssl/certs/hkps.pool.sks-keyservers.net.pem
+keyserver hkps://keys.openpgp.org/
 
 # Set the proxy to use for HTTP and HKP keyservers - default to the standard
 # local Tor socks proxy


### PR DESCRIPTION
* While the sks-keyservers hkps pool served well for a long time, it requires
  the consent of a single human to sign any certificates for people who wish
  their servers to be included in the pool. This person is currently MIA.
* The software running SKS has privacy and scaling concerns which are largely
  unfixable. SKS was written in Ocaml, as a proof of concept for yminsky's
  PhD thesis, and is more or less unmaintained these days because no one at
  Janestreet wants to adopt it. It is particularly vulnerable to abuse by
  spamming large data objects embedded within keys.
* keys.openpgp.org is a new keyserver, written in Rust and released in 2019,
  and follows standard privacy concerns such as verifying emails before
  publishing them. This keyserver's SSL is signed by LetsEncrypt, which avoids
  the need for a snowflake CA.
* keys.openpgp.org is the default keyserver for Enigmal, GPG Tools, and others
  listed in https://keys.openpgp.org/about/usage